### PR TITLE
(MAINT) Pin powershell Az module version to 7.1.0

### DIFF
--- a/steps/powershell-step-run/Dockerfile
+++ b/steps/powershell-step-run/Dockerfile
@@ -39,7 +39,7 @@ COPY profile.ps1 /opt/microsoft/powershell/7/profile.ps1
 SHELL ["pwsh", "-Command"]
 
 # Install commonly-used PowerShell modules
-RUN Install-Module -Name Az -Force -Scope AllUsers
+RUN Install-Module -Name Az -RequiredVersion 7.1.0 -Force -Scope AllUsers
 
 # Copy the step file
 COPY step.ps1 /scripts/step.ps1


### PR DESCRIPTION
Manually validated that this makes the `Az.Mysql` and `Az.PostgreSql` modules available in the image. cc: @kyleterry 